### PR TITLE
Enable ZMK Studio for cornix left builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ include:
   # Use cornix without dongle
   - board: cornix_left
     # shield: cornix_indicator
+    snippet: studio-rpc-usb-uart
     artifact-name: cornix_left
 
   - board: cornix_right

--- a/build.yaml
+++ b/build.yaml
@@ -20,6 +20,7 @@ include:
 
   - board: cornix_left
     #shield: cornix_indicator
+    snippet: studio-rpc-usb-uart
     artifact-name: cornix_left_default
 
   - board: cornix_ph_left


### PR DESCRIPTION
## Summary
- enable the studio-rpc USB snippet for cornix_left builds so ZMK Studio works without the dongle
- document the updated snippet requirement in the README instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e546e97cf08332ae4e82db2ca777a2