### PR TITLE
Enable ZMK Studio for both cornix halves

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,12 @@ include:
   # Use cornix without dongle
   - board: cornix_left
     # shield: cornix_indicator
+    snippet: studio-rpc-usb-uart
     artifact-name: cornix_left
 
   - board: cornix_right
     # shield: cornix_indicator
+    snippet: studio-rpc-usb-uart
     artifact-name: cornix_right
 
   - board: cornix_right

--- a/build.yaml
+++ b/build.yaml
@@ -20,6 +20,7 @@ include:
 
   - board: cornix_left
     #shield: cornix_indicator
+    snippet: studio-rpc-usb-uart
     artifact-name: cornix_left_default
 
   - board: cornix_ph_left
@@ -28,6 +29,7 @@ include:
 
   - board: cornix_right
     #shield: cornix_indicator
+    snippet: studio-rpc-usb-uart
     artifact-name: cornix_right
 
   - board: cornix_right


### PR DESCRIPTION
## Summary
- enable the studio-rpc USB snippet for the `cornix_right` build so ZMK Studio works on either half without the dongle
- update the README instructions to mention the right half also needs the Studio snippet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e546e97cf08332ae4e82db2ca777a2